### PR TITLE
bug fix to the output of LPF which will be changed outside

### DIFF
--- a/AccelerationExplorer/src/com/kircherelectronics/accelerationexplorer/filter/ImuLaCfQuaternion.java
+++ b/AccelerationExplorer/src/com/kircherelectronics/accelerationexplorer/filter/ImuLaCfQuaternion.java
@@ -392,7 +392,7 @@ public class ImuLaCfQuaternion implements ImuLinearAccelerationInterface
 		quatGyro = quatGyro.multiply(filterCoefficient);
 
 		// Scale our quaternion for the accel/mag
-		quatAccelMag = quatAccelMag.multiply(1 - oneMinusCoeff);
+		quatAccelMag = quatAccelMag.multiply(oneMinusCoeff);
 
 		// ...and then add the two quaternions together.
 		// output[0] = alpha * output[0] + (1 - alpha) * input[0];

--- a/AccelerationExplorer/src/com/kircherelectronics/accelerationexplorer/filter/LowPassFilterSmoothing.java
+++ b/AccelerationExplorer/src/com/kircherelectronics/accelerationexplorer/filter/LowPassFilterSmoothing.java
@@ -91,7 +91,11 @@ public class LowPassFilterSmoothing
 			output[2] = alpha * output[2] + (1 - alpha) * input[2];
 		}
 
-		return output;
+		//return a copy of output so that it will not be modified outside
+		float[] result = new float[3];
+		System.arraycopy(output, 0, result, 0, output.length);
+
+		return result;
 	}
 
 	public void setTimeConstant(float timeConstant)


### PR DESCRIPTION
Bug fix:
1. Method addSamples() in class LowPassFilterSmoothing returns the member
array output and it will be changed outside, so that LPF doesn’t work.
2. The scale of quatAccelMag should be oneMinusCoeff, not 1 - oneMinusCoeff